### PR TITLE
bugfix: Support noteOn/noteOff messages from all MIDI channels

### DIFF
--- a/js/MIDIInput.js
+++ b/js/MIDIInput.js
@@ -58,7 +58,8 @@ export default class MIDIInput {
 		var note = message.data[1];
 		var velocity = message.data.length > 2 ? message.data[2] : 0; // a velocity value might not be included with a noteOff command
 
-		switch (command) {
+		// Mask off the lower nibble (MIDI channel, which we don't care about)
+		switch (command & 0xf0) {
 			case 144: // noteOn
 				if (velocity > 0) {
 					this.notes.add(note);


### PR DESCRIPTION
## What

https://github.com/adgad/mididorians/commit/480acaee2b59cf6784b17fa5bd33e85aaeb26082 use bitwise AND to mask off the nibble related to the MIDI channel.

## Why

MIDI instruments can be configured to one of 16 possible channels. `144` just maps to the first channel so the app wouldn't detect notes from a device that was broadcasting to another channel.

https://www.midi.org/specifications-old/item/table-2-expanded-messages-list-status-bytes

The code was taken from https://www.w3.org/TR/webmidi/#a-simple-monophonic-sine-wave-midi-synthesizer

